### PR TITLE
Include Mediapipe data in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Run the helper script to build the app:
 ./build.sh
 ```
 
+The build script uses the `--collect-data mediapipe` flag so MediaPipe's
+resource files are bundled into the executable.
+
 The executable will appear in the `dist/` folder. Launch it with an optional camera index just like the script:
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
 pyinstaller --onefile \
   --add-data "epoch-18_valAcc-0.735.h5:." \
   --add-data "sign_to_prediction_index_map.json:." \
+  --collect-data mediapipe \
   model_test.py


### PR DESCRIPTION
## Summary
- fail the build script on any error
- bundle Mediapipe's data files using `--collect-data mediapipe`
- document the new flag in the build instructions

## Testing
- `bash build.sh` *(fails: `pyinstaller` not found)*
- `pip install pyinstaller`
- `bash build.sh`
- `python model_test.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*
