### PR TITLE
Clean duplicate constants in test script

### DIFF
--- a/model_test.py
+++ b/model_test.py
@@ -8,6 +8,7 @@ import mediapipe as mp
 from collections import deque
 import argparse
 
+# ─── Глобальные константы ───────────────────────────────────────
 SEQ_LEN     = 64
 CHANNELS    = 543 * 3
 PAD         = 0.0
@@ -22,11 +23,6 @@ parser = argparse.ArgumentParser(description='ASL recognition demo')
 parser.add_argument('--camera', type=int, default=0,
                     help='Index of the camera to use (default: 0)')
 args = parser.parse_args()
-
-# ─── Глобальные константы ───────────────────────────────────────
-SEQ_LEN     = 64
-CHANNELS    = 543 * 3
-PAD         = 0.0
 
 # ─── Загружаем словарь «жест→индекс» и инвертируем ──────────────
 with open('sign_to_prediction_index_map.json', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- keep a single constants block near the imports in `model_test.py`
- remove the duplicate constant definitions further down

## Testing
- `python -m py_compile model_test.py`
