### PR TITLE
Handle build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Run the helper script to build the app:
 ./build.sh
 ```
 
+The script uses `set -e` so the build will stop if PyInstaller encounters an
+error.
+
 The executable will appear in the `dist/` folder. Launch it with an optional camera index just like the script:
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 pyinstaller --onefile \
   --add-data "epoch-18_valAcc-0.735.h5:." \


### PR DESCRIPTION
## Summary
- fail fast in `build.sh` by enabling `set -e`
- describe this behavior in the README

## Testing
- `python -m py_compile model_test.py`
- `bash build.sh`
