### PR TITLE
Fix duplicate constant block in model_test

### DIFF
--- a/model_test.py
+++ b/model_test.py
@@ -24,10 +24,6 @@ parser.add_argument('--camera', type=int, default=0,
                     help='Index of the camera to use (default: 0)')
 args = parser.parse_args()
 
-# ─── Глобальные константы ───────────────────────────────────────
-SEQ_LEN     = 64
-CHANNELS    = 543 * 3
-PAD         = 0.0
 
 # ─── Загружаем словарь «жест→индекс» и инвертируем ──────────────
 with open('sign_to_prediction_index_map.json', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- remove duplicate constant declarations in `model_test.py`
- keep initial definitions near imports

## Testing
- `python -m py_compile model_test.py`
