### PR TITLE
Fix .gitignore trailing blank line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 Thumbs.db
 
 Отчет/
+


### PR DESCRIPTION
## Summary
- ensure `.gitignore` ends with a blank line

## Testing
- `git show --stat`
